### PR TITLE
Add automated npm publishing workflow on version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - 'package.json'
 
+permissions:
+  contents: write  # needed to push git tags
+  id-token: write  # needed for npm trusted publishing (OIDC)
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -43,6 +47,4 @@ jobs:
 
       - name: Publish to npm
         if: steps.version.outputs.changed == 'true'
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,21 +1,48 @@
-name: Publish to npm
+name: Publish on version bump
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches:
+      - master
+    paths:
+      - 'package.json'
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check version change
+        id: version
+        run: |
+          CURRENT=$(jq -r '.version' package.json)
+          PREVIOUS=$(git show HEAD~1:package.json | jq -r '.version')
+          echo "current=$CURRENT" >> $GITHUB_OUTPUT
+          if [ "$CURRENT" != "$PREVIOUS" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create git tag
+        if: steps.version.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ steps.version.outputs.current }}"
+          git push origin "v${{ steps.version.outputs.current }}"
 
       - uses: actions/setup-node@v4
+        if: steps.version.outputs.changed == 'true'
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      - run: npm publish
+      - name: Publish to npm
+        if: steps.version.outputs.changed == 'true'
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
   },
   "scripts": {
     "test": "echo \"No test specified\""
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow that automatically publishes the package to npm whenever the version in `package.json` is bumped on the master branch.

## Key Changes
- **New workflow file** (`.github/workflows/publish.yml`): Implements automated publishing with the following features:
  - Triggers on pushes to master that modify `package.json`
  - Detects version changes by comparing current and previous versions
  - Creates and pushes a git tag matching the new version
  - Publishes to npm using Node.js 20 with OIDC-based trusted publishing
  - Uses appropriate permissions for git operations and npm authentication

- **Updated `package.json`**: Added `publishConfig` with `"access": "public"` to ensure the package is published as a public npm package

## Implementation Details
- The workflow uses `fetch-depth: 2` to access the previous commit for version comparison
- Version detection is done via `jq` parsing of `package.json`
- Git operations are performed by the `github-actions[bot]` user
- All publishing steps are conditional on a detected version change, preventing unnecessary operations
- Uses npm's provenance feature for enhanced security and transparency

https://claude.ai/code/session_01UgQVYvqkbQ29G1HG4tkeX1